### PR TITLE
feat: added config option to enable/disable an URL validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,8 @@ var editor = EditorJS({
         rel: 'nofollow',
         availableTargets: ['_blank', '_self'],
         availableRels: ['author', 'noreferrer'],
-      }     
+        validate: false,
+      }
     },
 
     ...

--- a/example/package.json
+++ b/example/package.json
@@ -15,7 +15,8 @@
     "start": "react-scripts start",
     "build": "react-scripts build",
     "test": "react-scripts test",
-    "eject": "react-scripts eject"
+    "eject": "react-scripts eject",
+    "symlink": "cd node_modules && ln -s ../.. ./editorjs-hyperlink"
   },
   "eslintConfig": {
     "extends": [

--- a/example/src/EditorJsTool.js
+++ b/example/src/EditorJsTool.js
@@ -16,6 +16,7 @@ export const EDITOR_JS_TOOLS: { [toolName: string]: ToolConstructable | ToolSett
             shortcut: 'CMD+L',
             target: '_blank', // default null
             rel: 'nofollow', // default null
+            validate: false
         },
     },
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "editorjs-hyperlink",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/Hyperlink.js
+++ b/src/Hyperlink.js
@@ -242,15 +242,15 @@ export default class Hyperlink {
             this.closeActions();
         }
 
-        // if (!this.validateURL(value)) {
-        //     this.tooltip.show(this.nodes.input, 'Pasted link is not valid.', {
-        //         placement: 'top',
-        //     });
-        //     setTimeout(() => {
-        //         this.tooltip.hide();
-        //     }, 1000);
-        //     return;
-        // }
+        if (!!this.config.validate && !!this.config.validate === true && !this.validateURL(value)) {
+            this.tooltip.show(this.nodes.input, 'The URL is not valid.', {
+                placement: 'top',
+            });
+            setTimeout(() => {
+                this.tooltip.hide();
+            }, 1000);
+            return;
+        }
 
         value = this.prepareLink(value);
 


### PR DESCRIPTION
Hi @trinhtam 

Could you please review the change and accept it if everything is OK?

The idea is to make the URL validation optional and make it possible to configure the plugin in a way we need it.

**Please bump the package version and push it to NPM if this is fine.**

Feel free to ask any questions :)