### PR TITLE
feat: hide select controls if nothing to choose

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,8 +80,10 @@ var editor = EditorJS({
 | shortcut  | `string` | Shortcut, defaults to 'CMD+L' |
 | target | `string` | Defines a default target, defaults to null |
 | rel | `string` | Defines a default rel, defaults to null |
-| availableTargets | `string[]` | Available link targets, defaults to all targets |
-| availableRels | `string[]` | Available link rels, defaults to all rels |
+| availableTargets | `string[]` | Available link targets, defaults to all targets.<br>If empty array is provided, the control will be hidden and the default value applied. |
+| availableRels | `string[]` | Available link rels, defaults to all rels.<br>If empty array is provided, the control will be hidden and the default value applied. |
+| validate | `boolean` | Defines if an URL should be validated on saving |
+
 
 ## License
 [MIT](https://tamit.info)

--- a/example/src/App.js
+++ b/example/src/App.js
@@ -6,7 +6,7 @@ function App() {
   let data = {};
   return (
     <div className="App">
-      <EditorJs data={data} tools={EDITOR_JS_TOOLS} />;
+      <EditorJs data={data} tools={EDITOR_JS_TOOLS} onChange={(api, data) => {console.log(data)}} />;
     </div>
   );
 }

--- a/example/src/EditorJsTool.js
+++ b/example/src/EditorJsTool.js
@@ -16,6 +16,8 @@ export const EDITOR_JS_TOOLS: { [toolName: string]: ToolConstructable | ToolSett
             shortcut: 'CMD+L',
             target: '_blank', // default null
             rel: 'nofollow', // default null
+            availableTargets: ['_blank', '_self'],
+            availableRels: ['author', 'noreferrer'],
             validate: false
         },
     },

--- a/src/Hyperlink.js
+++ b/src/Hyperlink.js
@@ -91,6 +91,10 @@ export default class Hyperlink {
         }
 
         if(!!this.config.target) {
+            if(this.targetAttributes.length === 0) {
+                this.addOption(this.nodes.selectTarget, this.config.target, this.config.target);
+            }
+
             this.nodes.selectTarget.value = this.config.target;
         }
 
@@ -101,7 +105,12 @@ export default class Hyperlink {
         for (i=0; i<this.relAttributes.length; i++) {
             this.addOption(this.nodes.selectRel, this.relAttributes[i], this.relAttributes[i]);
         }
+
         if(!!this.config.rel) {
+            if(this.relAttributes.length === 0) {
+                this.addOption(this.nodes.selectTarget, this.config.rel, this.config.rel);
+            }
+
             this.nodes.selectRel.value = this.config.rel;
         }
 
@@ -116,8 +125,15 @@ export default class Hyperlink {
 
         // append
         this.nodes.wrapper.appendChild(this.nodes.input);
-        this.nodes.wrapper.appendChild(this.nodes.selectTarget);
-        this.nodes.wrapper.appendChild(this.nodes.selectRel);
+
+        if(!!this.targetAttributes && this.targetAttributes.length > 0) {
+            this.nodes.wrapper.appendChild(this.nodes.selectTarget);
+        }
+
+        if(!!this.relAttributes && this.relAttributes.length > 0) {
+            this.nodes.wrapper.appendChild(this.nodes.selectRel);
+        }
+
         this.nodes.wrapper.appendChild(this.nodes.buttonSave);
 
         return this.nodes.wrapper;


### PR DESCRIPTION
Hi @trinhtam

Just another one :)

The idea is to hide select controls if we don't need them.

**Please do not forget to build and bump the package version. And push it to NPM if this is fine.**

Thank you for the plugin!